### PR TITLE
Deprecations and Node REPL Changes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/lib/lz_string.ex
+++ b/lib/lz_string.ex
@@ -2,18 +2,16 @@ defmodule LZString do
   use LZString.Base64
 
   @compress_dict %{
-    size_8:  0,
+    size_8: 0,
     size_16: 1,
-    eof:     2
+    eof: 2
   }
 
   @decompress_dict Enum.into(@compress_dict, %{}, fn {k, v} -> {v, k} end)
 
-  @size_8  @compress_dict[:size_8]
+  @size_8 @compress_dict[:size_8]
   @size_16 @compress_dict[:size_16]
-  @eof     @compress_dict[:eof]
-
-
+  @eof @compress_dict[:eof]
 
   @doc ~S"""
     Compresses the given String with the lz-string algorithm.
@@ -22,10 +20,11 @@ defmodule LZString do
        <<5, 133, 48, 54, 96, 246, 3, 64, 4, 9, 107, 2, 24, 22, 217, 180, 53, 51, 144, 0>>
   """
 
-  @spec compress(String.t) :: binary
+  @spec compress(String.t()) :: binary
   def compress(""), do: ""
+
   def compress(str) do
-    output = compress("", str, @compress_dict) |> :erlang.list_to_bitstring
+    output = compress("", str, @compress_dict) |> :erlang.list_to_bitstring()
 
     # the js implementation incorrectly adds padding when none is needed, so we do too.
     padding_bits = 16 - (output |> bit_size |> rem(16))
@@ -34,13 +33,14 @@ defmodule LZString do
     #     16 -> 0
     #     n -> n
     #   end
-    << output :: bitstring , 0 :: size(padding_bits) >>
+    <<output::bitstring, 0::size(padding_bits)>>
   end
 
-  def compress(w, << c :: utf8 >> <> rest, dict) do
-    c = << c :: utf8 >>
+  def compress(w, <<c::utf8>> <> rest, dict) do
+    c = <<c::utf8>>
 
     char_just_added = !Map.has_key?(dict, c)
+
     dict =
       if char_just_added do
         Map.put(dict, c, {:first_time, map_size(dict)})
@@ -49,6 +49,7 @@ defmodule LZString do
       end
 
     wc = w <> c
+
     if Map.has_key?(dict, wc) do
       compress(wc, rest, dict)
     else
@@ -61,25 +62,29 @@ defmodule LZString do
   def compress(w, "", dict) do
     size = num_bits(map_size(dict) - 1)
     {_dict, output} = w_output(w, dict, false)
-    [output, reverse(<< dict[:eof] :: size(size) >>)]
+    [output, reverse(<<dict[:eof]::size(size)>>)]
   end
 
   defp w_output([], _dict, _char_just_added), do: <<>>
+
   defp w_output(w, dict, char_just_added) do
     case Map.fetch(dict, w) do
       {:ok, {:first_time, dict_index}} ->
         dict = Map.put(dict, w, dict_index)
         marker_size = num_bits(dict_index)
-        << char_val :: utf8 >> = w
+        <<char_val::utf8>> = w
+
         {size_marker, char_size} =
           if num_bits(char_val) <= 8 do
             {dict[:size_8], 8}
           else
             {dict[:size_16], 16}
           end
-        size_marker_bits = reverse(<< size_marker :: size(marker_size) >>)
-        char_bits = reverse(<< char_val :: size(char_size)>>)
-        {dict, << size_marker_bits :: bitstring, char_bits :: bitstring >>}
+
+        size_marker_bits = reverse(<<size_marker::size(marker_size)>>)
+        char_bits = reverse(<<char_val::size(char_size)>>)
+        {dict, <<size_marker_bits::bitstring, char_bits::bitstring>>}
+
       {:ok, dict_index} ->
         map_size = map_size(dict) - 1
         # a char just being added to the dict may cause us to add an extra bit
@@ -90,11 +95,11 @@ defmodule LZString do
           else
             map_size
           end
+
         size = num_bits(map_size)
-        {dict, reverse(<< dict_index :: size(size) >>)}
+        {dict, reverse(<<dict_index::size(size)>>)}
     end
   end
-
 
   @doc ~S"""
   Decompresses the given binary with the lz-string algorithm.
@@ -103,11 +108,12 @@ defmodule LZString do
     "hello, i am a 猫"
   """
 
-  @spec decompress(binary) :: String.t
+  @spec decompress(binary) :: String.t()
   def decompress(""), do: ""
+
   def decompress(str) do
     {:char, c, rest, dict} = decode_next_segment(str, @decompress_dict)
-    decompress(c, rest, dict) |> :erlang.list_to_binary |> :unicode.characters_to_binary(:utf16)
+    decompress(c, rest, dict) |> :erlang.list_to_binary() |> :unicode.characters_to_binary(:utf16)
   end
 
   def decompress(w, str, dict) do
@@ -115,65 +121,76 @@ defmodule LZString do
       {:char, c, rest, dict} ->
         dict = Map.put(dict, map_size(dict), w <> c)
         [w | decompress(c, rest, dict)]
+
       {:seq, seq, rest} ->
-        c = case Map.fetch(dict, seq) do
-              {:ok, decompressed} -> decompressed
-              :error ->
-                unless map_size(dict) == seq, do: raise "unknown sequence index #{seq}"
-                w <> first_utf16(w)
-            end
+        c =
+          case Map.fetch(dict, seq) do
+            {:ok, decompressed} ->
+              decompressed
+
+            :error ->
+              unless map_size(dict) == seq, do: raise("unknown sequence index #{seq}")
+              w <> first_utf16(w)
+          end
+
         dict = Map.put(dict, map_size(dict), w <> first_utf16(c))
         [w | decompress(c, rest, dict)]
-      :eof -> [w]
+
+      :eof ->
+        [w]
     end
   end
 
   defp decode_next_segment(str, dict) do
     size = dict |> map_size |> num_bits
-    << dict_entry :: size(size), rest :: bitstring >> = str
+    <<dict_entry::size(size), rest::bitstring>> = str
     # dict_entry is in LSB format, bring it back to MSB
-    << dict_entry :: size(size) >> = reverse(<< dict_entry :: size(size) >>)
+    <<dict_entry::size(size)>> = reverse(<<dict_entry::size(size)>>)
 
     case dict_entry do
       @size_8 ->
-        << c :: size(8), rest :: bitstring >> = rest
-        << c :: size(8) >> = reverse(<< c :: size(8)>>)
-        char = << c :: utf16 >>
+        <<c::size(8), rest::bitstring>> = rest
+        <<c::size(8)>> = reverse(<<c::size(8)>>)
+        char = <<c::utf16>>
         dict = Map.put(dict, map_size(dict), char)
         {:char, char, rest, dict}
+
       @size_16 ->
-        << c :: size(16), rest :: bitstring >> = rest
-        << c :: size(16) >> = reverse(<< c :: size(16)>>)
-        char = << c :: 16 >>
+        <<c::size(16), rest::bitstring>> = rest
+        <<c::size(16)>> = reverse(<<c::size(16)>>)
+        char = <<c::16>>
         dict = Map.put(dict, map_size(dict), char)
         {:char, char, rest, dict}
+
       @eof ->
         :eof
+
       index ->
         {:seq, index, rest}
     end
   end
 
-  defp first_utf16(<< c :: 16 >> <> _) do
-    << c :: 16 >>
+  defp first_utf16(<<c::16>> <> _) do
+    <<c::16>>
   end
 
   defp num_bits(0), do: 1
+
   defp num_bits(int) do
     int
-    |> :math.log2
+    |> :math.log2()
     |> trunc
     |> Kernel.+(1)
   end
 
   # http://erlang.org/euc/07/papers/1700Gustafsson.pdf
   defp reverse(<<>>), do: <<>>
-  defp reverse(<< bit :: size(1), rest :: bitstring >>) do
-    << reverse(rest) :: bitstring, bit :: size(1) >>
+
+  defp reverse(<<bit::size(1), rest::bitstring>>) do
+    <<reverse(rest)::bitstring, bit::size(1)>>
   end
 
   def debug(bitstring) do
-    for << bit :: size(1) <- bitstring >>, do: bit
+    for <<bit::size(1) <- bitstring>>, do: bit
   end
-
 end

--- a/lib/lz_string/base64.ex
+++ b/lib/lz_string/base64.ex
@@ -1,10 +1,9 @@
 defmodule LZString.Base64 do
-
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
-  |> String.to_char_list
-  |> Enum.with_index
+  |> String.to_char_list()
+  |> Enum.with_index()
   |> Enum.each(fn {c, i} ->
-    def base64_to_bitstring(unquote(c)), do: << unquote(i) :: size(6) >>
+    def base64_to_bitstring(unquote(c)), do: <<unquote(i)::size(6)>>
   end)
 
   defmacro __using__(_env) do
@@ -16,7 +15,7 @@ defmodule LZString.Base64 do
           "BYUwNmD2A0AECWsCGBbZtDUzkAA="
       """
       def compress_base64(str) do
-        str |> compress |> Base.encode64
+        str |> compress |> Base.encode64()
       end
 
       @doc ~S"""
@@ -29,7 +28,6 @@ defmodule LZString.Base64 do
         str |> decode_base64 |> decompress
       end
 
-
       @doc ~S"""
       Decodes the given "base64" string, giving a naked lz-string bitstring.
 
@@ -37,7 +35,7 @@ defmodule LZString.Base64 do
       <<5, 133, 48, 54, 96, 246, 3, 64, 4, 9, 107, 2, 24, 22, 217, 180, 53, 51, 144, 0, 0>>
       """
       def decode_base64(str) do
-        for << c :: utf8 <- str >>, into: <<>> do
+        for <<c::utf8 <- str>>, into: <<>> do
           LZString.Base64.base64_to_bitstring(c)
         end
       end
@@ -80,7 +78,6 @@ defmodule LZString.Base64 do
         |> String.replace("$", "=")
         |> decode_base64
       end
-
     end
   end
 end

--- a/lib/lz_string/base64.ex
+++ b/lib/lz_string/base64.ex
@@ -1,6 +1,6 @@
 defmodule LZString.Base64 do
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
-  |> String.to_char_list()
+  |> String.to_charlist()
   |> Enum.with_index()
   |> Enum.each(fn {c, i} ->
     def base64_to_bitstring(unquote(c)), do: <<unquote(i)::size(6)>>

--- a/mix.exs
+++ b/mix.exs
@@ -2,12 +2,14 @@ defmodule LzString.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :lz_string,
-     version: "0.0.7",
-     elixir: "~> 1.2",
-     package: package(),
-     deps: deps(),
-     description: "Elixir implementation of pieroxy's lz-string compression algorithm."]
+    [
+      app: :lz_string,
+      version: "0.0.7",
+      elixir: "~> 1.2",
+      package: package(),
+      deps: deps(),
+      description: "Elixir implementation of pieroxy's lz-string compression algorithm."
+    ]
   end
 
   # Configuration for the OTP application
@@ -31,8 +33,10 @@ defmodule LzString.Mixfile do
   end
 
   defp package do
-    [maintainers: ["Michael Shapiro"],
-     licenses: ["MIT"],
-     links: %{"GitHub": "https://github.com/koudelka/elixir-lz-string"}]
+    [
+      maintainers: ["Michael Shapiro"],
+      licenses: ["MIT"],
+      links: %{GitHub: "https://github.com/koudelka/elixir-lz-string"}
+    ]
   end
 end

--- a/test/lz_string/reference_test.exs
+++ b/test/lz_string/reference_test.exs
@@ -21,12 +21,12 @@ defmodule LzStringTest.Reference.Test do
   test "compress/1 should match output from the reference implementation for repeated ascii", %{
     port: port
   } do
-    Enum.each(1..2000, &assert_same_as_node_compress(String.ljust("", &1, ?a), port))
+    Enum.each(1..2000, &assert_same_as_node_compress(String.pad_trailing("", &1, "a"), port))
   end
 
   test "compress/1 should match output from the reference implementation for repeated multibyte char strings",
        %{port: port} do
-    Enum.each(1..2000, &assert_same_as_node_compress(String.ljust("", &1, ?猫), port))
+    Enum.each(1..2000, &assert_same_as_node_compress(String.pad_trailing("", &1, "猫"), port))
   end
 
   # compress using node, and decompress using elixir

--- a/test/lz_string/reference_test.exs
+++ b/test/lz_string/reference_test.exs
@@ -4,81 +4,95 @@ defmodule LzStringTest.Reference.Test do
   import LZString
 
   setup do
-    {:ok, port: TestHelper.lz_string_node_port}
+    {:ok, port: TestHelper.lz_string_node_port()}
   end
 
-  test "compress/1 should match output from the reference implementation for random strings", %{port: port} do
-    Enum.each 1..2000, fn _ ->
+  test "compress/1 should match output from the reference implementation for random strings", %{
+    port: port
+  } do
+    Enum.each(1..2000, fn _ ->
       1000
-      |> :crypto.strong_rand_bytes
-      |> Base.encode16
+      |> :crypto.strong_rand_bytes()
+      |> Base.encode16()
       |> assert_same_as_node_compress(port)
-    end
+    end)
   end
 
-  test "compress/1 should match output from the reference implementation for repeated ascii", %{port: port} do
-    Enum.each 1..2000, &(assert_same_as_node_compress String.ljust("", &1, ?a), port)
+  test "compress/1 should match output from the reference implementation for repeated ascii", %{
+    port: port
+  } do
+    Enum.each(1..2000, &assert_same_as_node_compress(String.ljust("", &1, ?a), port))
   end
 
-  test "compress/1 should match output from the reference implementation for repeated multibyte char strings", %{port: port} do
-    Enum.each 1..2000, &(assert_same_as_node_compress String.ljust("", &1, ?猫), port)
+  test "compress/1 should match output from the reference implementation for repeated multibyte char strings",
+       %{port: port} do
+    Enum.each(1..2000, &assert_same_as_node_compress(String.ljust("", &1, ?猫), port))
   end
 
   # compress using node, and decompress using elixir
 
-  test "decompress/1 should be able to decompress random strings from the reference implementation's compressToUint8Array/1", %{port: port} do
+  test "decompress/1 should be able to decompress random strings from the reference implementation's compressToUint8Array/1",
+       %{port: port} do
     Enum.each(1..2000, fn _ ->
-      str = 1000
-      |> :crypto.strong_rand_bytes
-      |> Base.encode16
+      str =
+        1000
+        |> :crypto.strong_rand_bytes()
+        |> Base.encode16()
 
       assert str == compress_to_binary_with_node(port, str) |> decompress
     end)
   end
 
-  test "decompress/1 should be able to decompress multi-byte utf8 from the reference implementation's compressToUint8Array/1", %{port: port} do
+  test "decompress/1 should be able to decompress multi-byte utf8 from the reference implementation's compressToUint8Array/1",
+       %{port: port} do
     str = "今日は 今日は 今日は 今日は 今日は 今日は"
     assert str == compress_to_binary_with_node(port, str) |> decompress
   end
 
-  test "decompress/1 should be able to handle utf-16 characters with surrogate pairs", %{port: port} do
+  test "decompress/1 should be able to handle utf-16 characters with surrogate pairs", %{
+    port: port
+  } do
     str = "abc💔abc"
     assert str == compress_to_binary_with_node(port, str) |> decompress
   end
 
-
   # compress to lz-string pseudo-base64 using node, and decompress using elixir
 
-  test "decompress_base64/1 should be able to decompress random strings from the reference implementation's compressToBase64/1", %{port: port} do
+  test "decompress_base64/1 should be able to decompress random strings from the reference implementation's compressToBase64/1",
+       %{port: port} do
     Enum.each(1..2000, fn _ ->
-      str = 1000
-      |> :crypto.strong_rand_bytes
-      |> Base.encode16
+      str =
+        1000
+        |> :crypto.strong_rand_bytes()
+        |> Base.encode16()
 
       assert str == compress_to_base64_with_node(port, str) |> decompress_base64
     end)
   end
 
-  test "decompress_base64/1 should be able to decompress multi-byte utf8 from the reference implementation's compressToBase64/1", %{port: port} do
+  test "decompress_base64/1 should be able to decompress multi-byte utf8 from the reference implementation's compressToBase64/1",
+       %{port: port} do
     str = "今日は 今日は 今日は 今日は 今日は 今日は"
     assert str == compress_to_base64_with_node(port, str) |> decompress_base64
   end
 
   # compress to base64, and decompress using node
 
-  test "the reference implementation's decompressFromBase64/1 should be able to random strings from compress_base64/1", %{port: port} do
+  test "the reference implementation's decompressFromBase64/1 should be able to random strings from compress_base64/1",
+       %{port: port} do
     Enum.each(1..2000, fn _ ->
-      str = 1000
-      |> :crypto.strong_rand_bytes
-      |> Base.encode16
+      str =
+        1000
+        |> :crypto.strong_rand_bytes()
+        |> Base.encode16()
 
       assert str == compress_base64(str) |> decompress_base64_with_node(port)
     end)
   end
 
-  test "the reference implementation's decompressFromBase64/1 should be able to decompress multi-byte utf8 from compress_base64/1", %{port: port} do
+  test "the reference implementation's decompressFromBase64/1 should be able to decompress multi-byte utf8 from compress_base64/1",
+       %{port: port} do
     str = "今日は 今日は 今日は 今日は 今日は 今日は"
     assert str == compress_base64(str) |> decompress_base64_with_node(port)
   end
-
 end

--- a/test/lz_string_test.exs
+++ b/test/lz_string_test.exs
@@ -5,11 +5,11 @@ defmodule LzStringTest do
   doctest LZString
 
   test "roundtrip repeated single-bute strings" do
-    Enum.each(1..2000, &assert_roundtrip(String.ljust("", &1, ?a)))
+    Enum.each(1..2000, &assert_roundtrip(String.pad_trailing("", &1, "a")))
   end
 
   test "roundtrip repeated multi-byte char strings" do
-    Enum.each(1..2000, &assert_roundtrip(String.ljust("", &1, ?猫)))
+    Enum.each(1..2000, &assert_roundtrip(String.pad_trailing("", &1, "猫")))
   end
 
   test "roundtrip random high entropy strings" do

--- a/test/lz_string_test.exs
+++ b/test/lz_string_test.exs
@@ -5,33 +5,32 @@ defmodule LzStringTest do
   doctest LZString
 
   test "roundtrip repeated single-bute strings" do
-    Enum.each 1..2000, &(assert_roundtrip String.ljust("", &1, ?a))
+    Enum.each(1..2000, &assert_roundtrip(String.ljust("", &1, ?a)))
   end
 
   test "roundtrip repeated multi-byte char strings" do
-    Enum.each 1..2000, &(assert_roundtrip String.ljust("", &1, ?猫))
+    Enum.each(1..2000, &assert_roundtrip(String.ljust("", &1, ?猫)))
   end
 
   test "roundtrip random high entropy strings" do
-    Enum.each 1..1000, fn _ ->
+    Enum.each(1..1000, fn _ ->
       1000
       |> random_string
       |> assert_roundtrip
-    end
+    end)
   end
 
   test "roundtrip random large low entropy string" do
     1_000_000
-    |> :crypto.strong_rand_bytes
-    |> Base.encode16
+    |> :crypto.strong_rand_bytes()
+    |> Base.encode16()
     |> assert_roundtrip
   end
 
   test "compress/1 should be able to handle every valid utf8 character that fits in two bytes" do
     valid_utf8_char_ranges()
-    |> Enum.flat_map(fn range -> Enum.map(range, &(<< &1 :: utf8 >>)) end)
-    |> :erlang.list_to_binary
+    |> Enum.flat_map(fn range -> Enum.map(range, &<<&1::utf8>>) end)
+    |> :erlang.list_to_binary()
     |> assert_roundtrip
   end
-
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -56,19 +56,19 @@ defmodule TestHelper do
     str = String.replace(str, "'", "\'")
 
     repl_eval(port, "LZString.compressToBase64('#{str}')")
-    |> String.strip(?')
+    |> String.trim("'")
   end
 
   def decompress_base64_with_node(str, port) do
     repl_eval(port, "LZString.decompressFromBase64('#{str}')")
-    |> String.strip(?')
+    |> String.trim("'")
   end
 
   def compress_to_binary_with_node(port, str) do
     str = String.replace(str, "'", "\'")
 
     repl_eval(port, "LZString.compressToUint8Array('#{str}').join(',')")
-    |> String.strip(?')
+    |> String.trim("'")
     |> String.split(",")
     |> Enum.map(&String.to_integer/1)
     |> :erlang.list_to_binary()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,4 @@
 defmodule TestHelper do
-
   # chars in the "surrogate pair" range are invalid on their own
   @surrogate_pair_start "D800" |> :erlang.binary_to_integer(16) |> Kernel.-(1)
   @surrogate_pair_stop "DFFF" |> :erlang.binary_to_integer(16) |> Kernel.+(1)
@@ -29,11 +28,11 @@ defmodule TestHelper do
 
   def random_string(size) do
     Enum.map(0..size, fn _ -> random_utf8_char() end)
-    |> :erlang.list_to_binary
+    |> :erlang.list_to_binary()
   end
 
   def random_utf8_char do
-    << random_int_in_range() :: utf8 >>
+    <<random_int_in_range()::utf8>>
   end
 
   def random_int_in_range do
@@ -55,22 +54,24 @@ defmodule TestHelper do
 
   def compress_to_base64_with_node(port, str) do
     str = String.replace(str, "'", "\'")
+
     repl_eval(port, "LZString.compressToBase64('#{str}')")
-    |> String.strip(?') #'
+    |> String.strip(?')
   end
 
   def decompress_base64_with_node(str, port) do
     repl_eval(port, "LZString.decompressFromBase64('#{str}')")
-    |> String.strip(?') #'
+    |> String.strip(?')
   end
 
   def compress_to_binary_with_node(port, str) do
     str = String.replace(str, "'", "\'")
+
     repl_eval(port, "LZString.compressToUint8Array('#{str}').join(',')")
-    |> String.strip(?') #'
+    |> String.strip(?')
     |> String.split(",")
     |> Enum.map(&String.to_integer/1)
-    |> :erlang.list_to_binary
+    |> :erlang.list_to_binary()
   end
 
   def lz_string_node_port do
@@ -90,10 +91,9 @@ defmodule TestHelper do
       {^port, {:data, "> "}} -> wait_for_result(port)
       {^port, {:data, "> " <> rest}} -> rest
       {^port, {:data, result}} -> result |> String.replace_suffix("> ", "")
-    end |> String.strip
+    end
+    |> String.strip()
   end
-
 end
-
 
 ExUnit.start()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -77,6 +77,8 @@ defmodule TestHelper do
   def lz_string_node_port do
     port = Port.open({:spawn, "node -i"}, [:binary])
     repl_eval(port, "LZString = require('lz-string')")
+    # Clear buffer of output from require()
+    wait_for_result(port)
     port
   end
 
@@ -90,9 +92,9 @@ defmodule TestHelper do
     receive do
       {^port, {:data, "> "}} -> wait_for_result(port)
       {^port, {:data, "> " <> rest}} -> rest
-      {^port, {:data, result}} -> result |> String.replace_suffix("> ", "")
+      {^port, {:data, result}} -> result
     end
-    |> String.strip()
+    |> String.replace(~r/\s*\>?\s*$/, "")
   end
 end
 


### PR DESCRIPTION
Hello there 👋🏼 

This PR addresses the following routine maintenance tasks:

* Format all files with `mix format`
* Replace call to deprecated `String.to_char_list/1` with `String.to_charlist/1`
* In test-related files, replace deprecated `String.ljust/3` with `String.pad_trailing/3`, and `String.strip/1` with `String.trim/1`
* Address two issues with the Node.js 16 REPL output:
  * Calling `require()` prints a value, which was printed and evaluated by the tests. A quick fix is to flush the output immediately after requiring the module.
  * In my testing, output would occasionally arrive with odd combinations of whitespace and the `>` prompt. A quick fix is to use a more flexible regex when trimming the output.

Tested in Elixir 1.13.3 / OTP 24, with Node.js 16.14.2.